### PR TITLE
Change document root in the correct config file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
     && wget -O wkhtmltox.deb http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-jessie-amd64.deb \
     && dpkg -i wkhtmltox.deb
 
-RUN sed -i 's|DocumentRoot /var/www/html|DocumentRoot /var/www/html/web|' /etc/apache2/apache2.conf \
+RUN sed -i 's|DocumentRoot /var/www/html|DocumentRoot /var/www/html/web|' /etc/apache2/sites-available/000-default.conf \
     && echo "FallbackResource /index.php" >> /etc/apache2/apache2.conf
 
 COPY . /var/www/html


### PR DESCRIPTION
Hey Dries, it looked like the appache configuration wasn't correct. DocumentRoot configuration was moved to the 000-default.cnf config file.
